### PR TITLE
Items_countカラムの追加

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
-  belongs_to :shop
-  belongs_to :brand
+  belongs_to :shop, counter_cache: :items_count
+  belongs_to :brand, counter_cache: :items_count
   belongs_to :top_category
   belongs_to :sub_category
   belongs_to :coupon

--- a/db/migrate/20181004103513_add_count_to_brands_shops.rb
+++ b/db/migrate/20181004103513_add_count_to_brands_shops.rb
@@ -1,0 +1,6 @@
+class AddCountToBrandsShops < ActiveRecord::Migration[5.0]
+  def change
+    add_column :brands, :items_count, :integer
+    add_column :shops, :items_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181004024509) do
+ActiveRecord::Schema.define(version: 20181004103513) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",       null: false
+    t.string   "name",        null: false
     t.string   "url"
-    t.string   "gender",     null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "gender",      null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.integer  "items_count"
     t.index ["name"], name: "index_brands_on_name", using: :btree
   end
 
@@ -130,13 +131,14 @@ ActiveRecord::Schema.define(version: 20181004024509) do
   end
 
   create_table "shops", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",                     null: false
-    t.text     "concept",    limit: 65535
+    t.string   "name",                      null: false
+    t.text     "concept",     limit: 65535
     t.string   "url"
-    t.string   "gender",                   null: false
+    t.string   "gender",                    null: false
     t.string   "logo"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.integer  "items_count"
     t.index ["name"], name: "index_shops_on_name", using: :btree
   end
 


### PR DESCRIPTION
# what
Items_countカラムをshops, bransテーブルに追加

# why
ブランドとショップのアイテム数のカウントのため。