### PR TITLE
以前チェックしたアイテムの表示

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,30 +10,4 @@ class ApplicationController < ActionController::Base
       devise_parameter_sanitizer.permit(:sign_up, keys: key)
     end
   end
-
-  def search_items_by_gender(url, items)
-    if url.include?("mens")
-      return @items.where("(gender = ?) OR (gender = ?)", 1, 4)
-    elsif url.include?("ladies")
-      return @items.where("(gender = ?) OR (gender = ?)", 2, 4)
-    elsif url.include?("kids")
-      return @items.where("(gender = ?) OR (gender = ?)", 3, 4)
-    else
-      return @items
-    end
-  end
-
-  def search_items_by_brand(url, items)
-    if url.include?("brands")
-      @items = @items.where(brand_id: params[:brand_id])
-    end
-    return @items
-  end
-
-  def search_items_by_shop(url, items)
-    if url.include?("shops")
-      @items = @items.where(shop_id: params[:shop_id])
-    end
-    return @items
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,12 +36,4 @@ class ApplicationController < ActionController::Base
     end
     return @items
   end
-
-  # 以前チェックしたアイテムを取得する
-  def get_checked_items
-    checked_items = current_user.checked_items.order("created_at DESC").map do |checked_item|
-       Item.includes(:images).find_by(id: checked_item.item_id)
-    end
-    return checked_items
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,4 +36,12 @@ class ApplicationController < ActionController::Base
     end
     return @items
   end
+
+  # 以前チェックしたアイテムを取得する
+  def get_checked_items
+    checked_items = current_user.checked_items.order("created_at DESC").map do |checked_item|
+       Item.includes(:images).find_by(id: checked_item.item_id)
+    end
+    return checked_items
+  end
 end

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -1,4 +1,5 @@
 class BrandsController < ApplicationController
+  include Search
   def index
     @brands = []
     # アルファベットで始まるショップの検索

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -7,6 +7,9 @@ class CartsController < ApplicationController
     @item_nums = @cart.item_nums.group(:number)
     @count = @item_nums.count
     @total_price = get_total_price(@items)
+
+    # チェックしたアイテム
+    @checked_items = get_checked_items
   end
 
   def create

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,5 +1,6 @@
 class CartsController < ApplicationController
-
+  include Checked
+  
   def index
     @cart = current_user.cart
     @items = @cart.items

--- a/app/controllers/concerns/checked.rb
+++ b/app/controllers/concerns/checked.rb
@@ -3,8 +3,8 @@ module Checked
   included do
     def get_checked_items
       # 以前閲覧したアイテムを取得する
-      checked_items = current_user.checked_items.order("created_at DESC").map do |checked_item|
-         Item.includes(:images).find_by(id: checked_item.item_id)
+      checked_items = current_user.checked_items.order("created_at DESC").group(:item_id).map do |checked_item|
+        Item.includes(:images).find_by(id: checked_item.item_id)
       end
       return checked_items
     end

--- a/app/controllers/concerns/checked.rb
+++ b/app/controllers/concerns/checked.rb
@@ -3,7 +3,7 @@ module Checked
   included do
     def get_checked_items
       # 以前閲覧したアイテムを取得する
-      checked_items = current_user.checked_items.order("created_at DESC").group(:item_id).map do |checked_item|
+      checked_items = current_user.checked_items.order("updated_at DESC").map do |checked_item|
         Item.includes(:images).find_by(id: checked_item.item_id)
       end
       return checked_items

--- a/app/controllers/concerns/checked.rb
+++ b/app/controllers/concerns/checked.rb
@@ -1,0 +1,12 @@
+module Checked
+  extend ActiveSupport::Concern
+  included do
+    def get_checked_items
+      # 以前閲覧したアイテムを取得する
+      checked_items = current_user.checked_items.order("created_at DESC").map do |checked_item|
+         Item.includes(:images).find_by(id: checked_item.item_id)
+      end
+      return checked_items
+    end
+  end
+end

--- a/app/controllers/concerns/search.rb
+++ b/app/controllers/concerns/search.rb
@@ -24,7 +24,7 @@ module Search
       if url.include?("shops")
         items = items.where(shop_id: params[:shop_id])
       end
-      return @items
+      return items
     end
   end
 end

--- a/app/controllers/concerns/search.rb
+++ b/app/controllers/concerns/search.rb
@@ -1,0 +1,30 @@
+module Search
+  extend ActiveSupport::Concern
+  included do
+    def search_items_by_gender(url, items)
+      if url.include?("mens")
+        return items.where("(gender = ?) OR (gender = ?)", 1, 4)
+      elsif url.include?("ladies")
+        return items.where("(gender = ?) OR (gender = ?)", 2, 4)
+      elsif url.include?("kids")
+        return items.where("(gender = ?) OR (gender = ?)", 3, 4)
+      else
+        return @items
+      end
+    end
+
+    def search_items_by_brand(url, items)
+      if url.include?("brands")
+        items = items.where(brand_id: params[:brand_id])
+      end
+      return items
+    end
+
+    def search_items_by_shop(url, items)
+      if url.include?("shops")
+        items = items.where(shop_id: params[:shop_id])
+      end
+      return @items
+    end
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,12 +11,17 @@ class ItemsController < ApplicationController
     @stock_count = @item.stocks.length
 
     # 「チェックしたアイテム」機能
-    checked_items = current_user.checked_items
-    # 同じアイテムを過去に閲覧していなければレコード作成
-    if checked_items.find_by(item_id: @item.id) == nil
-      checked_items.create(item_id: @item.id)
+    checked_item = current_user.checked_items.find_by(item_id: @item.id)
+    if checked_item == nil
+      # 同じアイテムを過去に閲覧していなければレコード作成
+      current_user.checked_items.create(item_id: @item.id)
+    else
+      # 閲覧していれば既存のレコードを削除
+      checked_item.destroy
+      current_user.checked_items.create(item_id: @item.id)
     end
-    if checked_items.length > 20
+
+    if current_user.checked_items.length > 20
       checked_items.first.destroy
     end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,15 +12,11 @@ class ItemsController < ApplicationController
 
     # 「チェックしたアイテム」機能
     checked_item = current_user.checked_items.find_by(item_id: @item.id)
-    if checked_item == nil
-      # 同じアイテムを過去に閲覧していなければレコード作成
-      current_user.checked_items.create(item_id: @item.id)
-    else
-      # 閲覧していれば既存のレコードを削除
-      checked_item.destroy
-      current_user.checked_items.create(item_id: @item.id)
-    end
+    # 既にアイテムを閲覧していれば既存のレコードを削除
+    checked_item.destroy if checked_item
+    current_user.checked_items.create(item_id: @item.id)
 
+    # チェックしたアイテムが規定数を超えた場合、古いレコードを削除
     if current_user.checked_items.length > 20
       checked_items.first.destroy
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,5 +9,16 @@ class ItemsController < ApplicationController
     @related_items = Item.where(shop_id: @item.shop.id)
     @color_count = @item.images.group(:color).length - 1 # -1: nilを除外
     @stock_count = @item.stocks.length
+
+    # 「チェックしたアイテム」機能
+    checked_items = current_user.checked_items
+    # 同じアイテムを過去に閲覧していなければレコード作成
+    if checked_items.find_by(item_id: @item.id) == nil
+      checked_items.create(item_id: @item.id)
+    end
+    if checked_items.length > 20
+      checked_items.first.destroy
+    end
+
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,15 +11,6 @@ class ItemsController < ApplicationController
     @stock_count = @item.stocks.length
 
     # 「チェックしたアイテム」機能
-    checked_item = current_user.checked_items.find_by(item_id: @item.id)
-    # 既にアイテムを閲覧していれば既存のレコードを削除
-    checked_item.destroy if checked_item
     current_user.checked_items.create(item_id: @item.id)
-
-    # チェックしたアイテムが規定数を超えた場合、古いレコードを削除
-    if current_user.checked_items.length > 20
-      checked_items.first.destroy
-    end
-
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,6 +11,11 @@ class ItemsController < ApplicationController
     @stock_count = @item.stocks.length
 
     # 「チェックしたアイテム」機能
-    current_user.checked_items.create(item_id: @item.id)
+    checked_item = current_user.checked_items.find_by(item_id: @item.id)
+    if checked_item
+      checked_item.save
+    else
+      current_user.checked_items.create(item_id: @item.id)
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,11 +11,6 @@ class ItemsController < ApplicationController
     @stock_count = @item.stocks.length
 
     # 「チェックしたアイテム」機能
-    checked_item = current_user.checked_items.find_by(item_id: @item.id)
-    if checked_item
-      checked_item.save
-    else
-      current_user.checked_items.create(item_id: @item.id)
-    end
+    current_user.checked_items.where(item_id: @item.id).first_or_create.update(updated_at: Time.now)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,6 +11,6 @@ class ItemsController < ApplicationController
     @stock_count = @item.stocks.length
 
     # 「チェックしたアイテム」機能
-    current_user.checked_items.where(item_id: @item.id).first_or_create.update(updated_at: Time.now)
+    current_user.checked_items.where(item_id: @item.id).first_or_create.update(updated_at: Time.current)
   end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,4 +1,5 @@
 class ShopsController < ApplicationController
+  include Search
   def index
     @shops = []
     # アルファベットで始まるショップの検索

--- a/app/controllers/sub_categories_controller.rb
+++ b/app/controllers/sub_categories_controller.rb
@@ -1,4 +1,5 @@
 class SubCategoriesController < ApplicationController
+  include Search
   def show
     @sub_category = SubCategory.find(params[:id])
     @top_category = @sub_category.top_category

--- a/app/controllers/top_categories_controller.rb
+++ b/app/controllers/top_categories_controller.rb
@@ -1,4 +1,5 @@
 class TopCategoriesController < ApplicationController
+  include Search
   def index
     @top_categories = TopCategory.all.includes(:sub_categories)
   end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,4 +1,6 @@
 class TopsController < ApplicationController
+  include Checked
+
   def index
     @zozo_brand = Brand.find_by(name: "ZOZO")
     @zozo_items = @zozo_brand.items.limit(3).includes(:images)

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -11,9 +11,7 @@ class TopsController < ApplicationController
     @shops = Shop.order("items_count DESC").limit(10)
 
     # チェックしたアイテム
-    @checked_items = current_user.checked_items.order("created_at DESC").map do |checked_item|
-       Item.includes(:images).find_by(id: checked_item.item_id)
-    end
+    @checked_items = get_checked_items
   end
 
   def men

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -5,10 +5,15 @@ class TopsController < ApplicationController
     # @coupon = Coupon.find_by(price: 5000)
     @coupon_items = Item.order("created_at DESC").limit(7)
     @rank_items = Item.order("created_at DESC").limit(7).includes(:images)
-    @checked_items = Item.order("created_at DESC").limit(15).includes(:images)
+
     @top_categories = TopCategory.all
     @brands = Brand.order("items_count DESC").limit(10)
     @shops = Shop.order("items_count DESC").limit(10)
+
+    # チェックしたアイテム
+    @checked_items = current_user.checked_items.map do |checked_item|
+       Item.includes(:images).find_by(id: checked_item.item_id)
+    end
   end
 
   def men

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -11,7 +11,7 @@ class TopsController < ApplicationController
     @shops = Shop.order("items_count DESC").limit(10)
 
     # チェックしたアイテム
-    @checked_items = current_user.checked_items.map do |checked_item|
+    @checked_items = current_user.checked_items.order("created_at DESC").map do |checked_item|
        Item.includes(:images).find_by(id: checked_item.item_id)
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,7 @@ class Item < ApplicationRecord
   has_many :carts, through: :shoppings
   # has_many :ordered_items
   # has_many :orders, through: :ordered_items
-  has_many :checked_items
+  has_many :checked_items, dependent: :destroy
   # has_many :favorite_items
 
   # enum gender: {all: 1, mens: 2, ladies: 3, kids: 4}

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,7 @@ class Item < ApplicationRecord
   has_many :carts, through: :shoppings
   # has_many :ordered_items
   # has_many :orders, through: :ordered_items
-  # has_many :checked_items
+  has_many :checked_items
   # has_many :favorite_items
 
   # enum gender: {all: 1, mens: 2, ladies: 3, kids: 4}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   # enum gender: { men: 1, women: 2, other: 3 }
 
   has_one :cart, dependent: :destroy
-  has_many :checked_items
+  has_many :checked_items, dependent: :destroy
   has_many :checked_shops
   has_many :favorite_items
   has_many :favorite_brands

--- a/app/views/carts/index.html.haml
+++ b/app/views/carts/index.html.haml
@@ -68,9 +68,10 @@
         .item-content
           %h3 チェックしたアイテム
           %ul#top__center__pickup__contents.clearfix
-            - 15.times.each do |i|
+            - @checked_items.each do |item|
               #top__center__pickup__contents__item
-                -# = render partial: 'tops/item', locals: {image_size: "middle", rank_num: 0, coupon: 0, shop_image: false}
+                - if item.images[0]
+                  = render partial: 'tops/item', locals: {item: item, image_size: "middle", rank_num: 0, coupon: 0, shop_image: false}
         .item-ranking
           %h3 人気アイテムランキング
           %ul#top__center__pickup__contents.clearfix

--- a/app/views/tops/_tops_center.html.haml
+++ b/app/views/tops/_tops_center.html.haml
@@ -38,7 +38,8 @@
   %ul#top__center__pickup__contents.clearfix
     - @checked_items.each do |item|
       #top__center__pickup__contents__item
-        = render partial: 'item', locals: {item: item, image_size: "small", rank_num: 0, coupon: 0, shop_image: false}
+        - if item.images[0]
+          = render partial: 'item', locals: {item: item, image_size: "small", rank_num: 0, coupon: 0, shop_image: false}
 %section#top__center__shops
   .section-header
     %h2 チェックしたショップ


### PR DESCRIPTION
# what
・以前チェックしたアイテムをトップページおよびショッピングカートに表示する機能を追加（アイテム詳細ページに遷移したらchecked_itemsテーブルにitem_idとuser_idを保存）

# why
基本機能のため