### PR TITLE
以前カートに入れたアイテム機能の実装

### DIFF
--- a/app/assets/stylesheets/carts.scss
+++ b/app/assets/stylesheets/carts.scss
@@ -338,3 +338,8 @@
     }
   }
 }
+
+.cart-image {
+  height: 150px;
+  width: 125px;
+}

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -21,7 +21,7 @@ class CartsController < ApplicationController
     redirect_to controller: 'carts', action: 'index'
 
     # 「以前カートに入れたアイテム」機能
-    current_user.past_carts.where(cart_id: current_user.cart, item_id: params[:item_id], item_num_id: params[:item_num_id]).first_or_create.update(updated_at: Time.current)
+    current_user.past_carts.where(item_num_id: params[:item_num_id]).first_or_create.update(updated_at: Time.current)
   end
 
   def destroy

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,5 +1,6 @@
 class CartsController < ApplicationController
   include Checked
+  include SavedCart
 
   def index
     @cart = current_user.cart
@@ -10,6 +11,9 @@ class CartsController < ApplicationController
     @total_price = get_total_price(@items)
     # チェックしたアイテム
     @checked_items = get_checked_items
+
+    # 「以前カートに入れたアイテム」機能
+    @past_item_nums = get_past_item_nums
   end
 
   def create

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,6 +1,6 @@
 class CartsController < ApplicationController
   include Checked
-  
+
   def index
     @cart = current_user.cart
     @items = @cart.items
@@ -15,6 +15,9 @@ class CartsController < ApplicationController
   def create
     Shopping.create(cart_params)
     redirect_to controller: 'carts', action: 'index'
+
+    # 「以前カートに入れたアイテム」機能
+    current_user.past_carts.where(cart_id: current_user.cart, item_id: params[:item_id], item_num_id: params[:item_num_id]).first_or_create.update(updated_at: Time.current)
   end
 
   def destroy

--- a/app/controllers/concerns/saved_cart.rb
+++ b/app/controllers/concerns/saved_cart.rb
@@ -1,0 +1,14 @@
+module SavedCart
+  extend ActiveSupport::Concern
+  included do
+    def get_past_item_nums
+      # 以前カートに入れたアイテムを取得する
+      past_all_item_nums = current_user.past_carts.order("updated_at DESC").map do |past_cart|
+        past_cart.item_num
+      end
+      set1 = Set.new(@item_nums) # 現在カートに入っているアイテム
+      set2 = Set.new(past_all_item_nums) # 過去にカートに入れた全てのアイテム
+      return set2 - set1
+    end
+  end
+end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,7 +1,9 @@
 class Cart < ApplicationRecord
   belongs_to :user
+  belongs_to :order
+
   has_many :shoppings
   has_many :items, through: :shoppings
   has_many :item_nums, through: :shoppings
-  belongs_to :order
+  has_many :past_carts, dependent: :destroy
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -5,5 +5,4 @@ class Cart < ApplicationRecord
   has_many :shoppings
   has_many :items, through: :shoppings
   has_many :item_nums, through: :shoppings
-  has_many :past_carts, dependent: :destroy
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,5 +14,4 @@ class Item < ApplicationRecord
   # has_many :orders, through: :ordered_items
   has_many :checked_items, dependent: :destroy
   # enum gender: {all: 1, mens: 2, ladies: 3, kids: 4}
-  has_many :past_carts, dependent: :destroy
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,4 +14,5 @@ class Item < ApplicationRecord
   # has_many :orders, through: :ordered_items
   has_many :checked_items, dependent: :destroy
   # enum gender: {all: 1, mens: 2, ladies: 3, kids: 4}
+  has_many :past_carts, dependent: :destroy
 end

--- a/app/models/item_num.rb
+++ b/app/models/item_num.rb
@@ -4,4 +4,5 @@ class ItemNum < ApplicationRecord
   has_many :shoppings
   has_many :carts, through: :shoppings
   has_many :favorite_items
+  has_many :past_carts, dependent: :destroy
 end

--- a/app/models/past_cart.rb
+++ b/app/models/past_cart.rb
@@ -1,6 +1,4 @@
 class PastCart < ApplicationRecord
   belongs_to :user
-  belongs_to :cart
-  belongs_to :item
   belongs_to :item_num
 end

--- a/app/models/past_cart.rb
+++ b/app/models/past_cart.rb
@@ -1,0 +1,2 @@
+class PastCart < ApplicationRecord
+end

--- a/app/models/past_cart.rb
+++ b/app/models/past_cart.rb
@@ -1,2 +1,6 @@
 class PastCart < ApplicationRecord
+  belongs_to :user
+  belongs_to :cart
+  belongs_to :item
+  belongs_to :item_num
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   # enum gender: { men: 1, women: 2, other: 3 }
-
   has_one :cart, dependent: :destroy
   has_many :checked_items, dependent: :destroy
   has_many :checked_shops
@@ -13,6 +12,5 @@ class User < ApplicationRecord
   has_many :favorite_shops
   has_many :deliverys
   has_many :orders
-  has_one :user
-
+  has_many :past_carts, dependent: :destroy
 end

--- a/app/views/carts/_cart_item.html.haml
+++ b/app/views/carts/_cart_item.html.haml
@@ -1,0 +1,16 @@
+.item-list
+  = link_to shop_item_path(item_num.item.shop, item_num.item) do
+    = image_tag item_num.item.images[0].url, class: "cart-image"
+  .name
+    %p
+      = item_num.item.shop.name
+    %p
+      = item_num.item.brand.name
+    .price
+      = number_to_currency(item_num.item.price, unit: "￥", precision: 0)
+    %span 税別
+    .other-text
+    .other-text
+      = "サイズ：" + item_num.stock.size
+  .cart-btn
+    = link_to "カートに入れる", carts_create_path(@cart)

--- a/app/views/carts/index.html.haml
+++ b/app/views/carts/index.html.haml
@@ -53,18 +53,8 @@
             %a{ :href => 'http://google.co.jp' }詳細
         .cart-in-item
           %h2 以前カートに入れたアイテム
-          .item-list
-            %a{ :href => 'http://google.co.jp' }
-              %img{alt: "商品イメージ", height: "150", width: "125", src: "https://c.imgz.jp/837/35099837/35099837B_1_D_215.jpg"}
-            .name
-              %p MONO-MART
-              %p 【Champion】
-              .price ¥9,990
-              %span 税別
-              .other-text カラー：ホワイト
-              .other-text サイズ：38
-            .cart-btn
-              %a{ :href => 'http://google.co.jp' }カートに入れる
+          = render partial: "cart_item", collection: @past_item_nums, as: "item_num"
+
         .item-content
           %h3 チェックしたアイテム
           %ul#top__center__pickup__contents.clearfix

--- a/db/migrate/20181009004916_create_past_carts.rb
+++ b/db/migrate/20181009004916_create_past_carts.rb
@@ -1,0 +1,11 @@
+class CreatePastCarts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :past_carts do |t|
+      t.integer :user_id, null: false, foreign_key: true
+      t.integer :cart_id, null: false, foreign_key: true
+      t.integer :item_id, null: false, foreign_key: true
+      t.integer :item_num_id, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181009030248_add_index_to_user_id.rb
+++ b/db/migrate/20181009030248_add_index_to_user_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToUserId < ActiveRecord::Migration[5.0]
+  def change
+    add_index :past_carts, :user_id
+  end
+end

--- a/db/migrate/20181009033906_delete_column_from_past_carts.rb
+++ b/db/migrate/20181009033906_delete_column_from_past_carts.rb
@@ -1,0 +1,6 @@
+class DeleteColumnFromPastCarts < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :past_carts, :cart_id, :integer
+    remove_column :past_carts, :item_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181008113750) do
+ActiveRecord::Schema.define(version: 20181009004916) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",        null: false
@@ -143,6 +143,15 @@ ActiveRecord::Schema.define(version: 20181008113750) do
     t.string   "delivery_day"
     t.string   "delivery_hour"
     t.integer  "payment_id",    null: false
+  end
+
+  create_table "past_carts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "user_id",     null: false
+    t.integer  "cart_id",     null: false
+    t.integer  "item_id",     null: false
+    t.integer  "item_num_id", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   create_table "payments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181009030248) do
+ActiveRecord::Schema.define(version: 20181009033906) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",        null: false
@@ -147,8 +147,6 @@ ActiveRecord::Schema.define(version: 20181009030248) do
 
   create_table "past_carts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id",     null: false
-    t.integer  "cart_id",     null: false
-    t.integer  "item_id",     null: false
     t.integer  "item_num_id", null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181009004916) do
+ActiveRecord::Schema.define(version: 20181009030248) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",        null: false
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 20181009004916) do
     t.integer  "item_num_id", null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.index ["user_id"], name: "index_past_carts_on_user_id", using: :btree
   end
 
   create_table "payments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
# What
・以前カートに入れたアイテムをカートのindexページに表示する

# Why
購買意欲促進のため

# Description
・「カートに入れる」ボタンを押したらpast_cartsテーブルにアイテムID、ユーザーID、カートIDを登録する
・「過去にカートに入れた全てのアイテム」と「現在カートに入っているアイテム」の差集合（Setオブジェクト）を求める
・今回使用するメソッドをモジュールに記載