### PR TITLE
ランキング機能の実装

### DIFF
--- a/app/assets/stylesheets/rankings.scss
+++ b/app/assets/stylesheets/rankings.scss
@@ -267,4 +267,6 @@
     }
   }
 }
-
+.sub_ranking {
+  margin: 0 15px;
+}

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -183,6 +183,16 @@ article {
   width: $small-image-width;
 }
 
+.image-size-super-large {
+  height: 370px;
+  width: 310px;
+}
+
+.image-size-high-large {
+  height: 260px;
+  width: 215px;
+}
+
 .shop-image {
   width: 150px;
   height: 50px;

--- a/app/controllers/concerns/ranking.rb
+++ b/app/controllers/concerns/ranking.rb
@@ -5,7 +5,7 @@ module Ranking
       # 規定日数以上閲覧されていないものと閲覧数が０のものは足切りする
       @items = Item.where("(checked_items_count > ?) and (created_at > ?)", 0, 7.days.ago)
 
-      a = 1 # 閲覧数の重み付け...1pt
+      a = 0.1 # 閲覧数の重み付け...0.1pt
       b = 2 # お気に入り登録数の重み付け...2pt
       c = 3 # カートに入れられている数の重み付け...3pt
       d = 4 # 注文数の重み付け...4pt

--- a/app/controllers/concerns/ranking.rb
+++ b/app/controllers/concerns/ranking.rb
@@ -5,15 +5,21 @@ module Ranking
       # 規定日数以上閲覧されていないものと閲覧数が０のものは足切りする
       @items = Item.where("(checked_items_count > ?) and (created_at > ?)", 0, 7.days.ago)
 
-      a = 0.1 # 閲覧数の重み付け...0.1pt
-      b = 2 # お気に入り登録数の重み付け...2pt
-      c = 3 # カートに入れられている数の重み付け...3pt
-      d = 4 # 注文数の重み付け...4pt
+      # 閲覧数の重み付け...0.1pt
+      # お気に入り登録数の重み付け...2pt
+      # カートに入れられている数の重み付け...3pt
+      # 注文数の重み付け...4pt
+      conf = {
+        checked_item: 0.1,
+        favorite_item: 2,
+        shopping_item: 3,
+        order_item: 4
+      }
       @rankings = {}
       @items.each do |item|
         # 各アイテムのscoreを計算しhashに格納する
         time_conf = (Time.current.day - item.created_at.day) / 10
-        score = (a * item.checked_items_count + b * item.favorite_items_count + c * item.shoppings_count + d * item.ordered_items_count) - time_conf
+        score = (conf[:checked_item] * item.checked_items_count + conf[:favorite_item] * item.favorite_items_count + conf[:shopping_item] * item.shoppings_count + conf[:order_item] * item.ordered_items_count) - time_conf
         @rankings.store(item, score)
       end
       # hashを降順にソートし配列として取得する

--- a/app/controllers/concerns/ranking.rb
+++ b/app/controllers/concerns/ranking.rb
@@ -1,0 +1,24 @@
+module Ranking
+  extend ActiveSupport::Concern
+  included do
+    def get_ranking_items
+      # 規定日数以上閲覧されていないものと閲覧数が０のものは足切りする
+      @items = Item.where("(checked_items_count > ?) and (created_at > ?)", 0, 7.days.ago)
+
+      a = 1 # 閲覧数の重み付け...1pt
+      b = 2 # お気に入り登録数の重み付け...2pt
+      c = 3 # カートに入れられている数の重み付け...3pt
+      d = 4 # 注文数の重み付け...4pt
+      @rankings = {}
+      @items.each do |item|
+        # 各アイテムのscoreを計算しhashに格納する
+        time_conf = (Time.current.day - item.created_at.day) / 10
+        score = (a * item.checked_items_count + b * item.favorite_items_count + c * item.shoppings_count + d * item.ordered_items_count) - time_conf
+        @rankings.store(item, score)
+      end
+      # hashを降順にソートし配列として取得する
+      return @rankings.sort {|(k1, v1), (k2, v2)| v2 <=> v1 }
+
+    end
+  end
+end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -8,7 +8,7 @@ class FavoritesController < ApplicationController
   end
 
   def create
-    current_user.favorite_items.create(item_num_id: params[:item_num_id])
+    current_user.favorite_items.create(item_id: params[:item_id], item_num_id: params[:item_num_id])
   end
 
   def brand_create

--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -1,21 +1,6 @@
 class RankingsController < ApplicationController
-
+  include Ranking
   def index
-    # 規定日数以上閲覧されていないものと閲覧数が０のものは足切りする
-    @items = Item.where("(checked_items_count > ?) and (created_at > ?)", 0, 7.days.ago)
-
-    a = 1 # 閲覧数の重み付け...1pt
-    b = 2 # お気に入り登録数の重み付け...2pt
-    c = 3 # カートに入れられている数の重み付け...3pt
-    d = 4 # 注文数の重み付け...4pt
-    @rankings = {}
-    @items.each do |item|
-      # 各アイテムのscoreを計算しhashに格納する
-      time_conf = (Time.current.day - item.created_at.day) / 10
-      score = (a * item.checked_items_count + b * item.favorite_items_count + c * item.shoppings_count + d * item.ordered_items_count) - time_conf
-      @rankings.store(item, score)
-    end
-    # hashを降順にソートし配列として取得する
-    @rankings = @rankings.sort {|(k1, v1), (k2, v2)| v2 <=> v1 }
+    @rankings = get_ranking_items
   end
 end

--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -1,6 +1,6 @@
 class RankingsController < ApplicationController
   include Ranking
   def index
-    @rankings = get_ranking_items[0, 100]
+    @rankings = get_ranking_items.slice(0, 100)
   end
 end

--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -1,5 +1,21 @@
 class RankingsController < ApplicationController
 
   def index
+    # 規定日数以上閲覧されていないものと閲覧数が０のものは足切りする
+    @items = Item.where("(checked_items_count > ?) and (created_at > ?)", 0, 7.days.ago)
+
+    a = 1 # 閲覧数の重み付け...1pt
+    b = 2 # お気に入り登録数の重み付け...2pt
+    c = 3 # カートに入れられている数の重み付け...3pt
+    d = 4 # 注文数の重み付け...4pt
+    @rankings = {}
+    @items.each do |item|
+      # 各アイテムのscoreを計算しhashに格納する
+      time_conf = (Time.current.day - item.created_at.day) / 10
+      score = (a * item.checked_items_count + b * item.favorite_items_count + c * item.shoppings_count + d * item.ordered_items_count) - time_conf
+      @rankings.store(item, score)
+    end
+    # hashを降順にソートし配列として取得する
+    @rankings = @rankings.sort {|(k1, v1), (k2, v2)| v2 <=> v1 }
   end
 end

--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -1,6 +1,6 @@
 class RankingsController < ApplicationController
   include Ranking
   def index
-    @rankings = get_ranking_items
+    @rankings = get_ranking_items[0, 100]
   end
 end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,11 +1,11 @@
 class TopsController < ApplicationController
   include Checked
+  include Ranking
   def index
     @zozo_brand = Brand.find_by(name: "ZOZO")
     @zozo_items = @zozo_brand.items.limit(3).includes(:images)
     # @coupon = Coupon.find_by(price: 5000)
     @coupon_items = Item.order("created_at DESC").limit(7)
-    @rank_items = Item.order("created_at DESC").limit(7).includes(:images)
     @top_categories = TopCategory.all
     @brands = Brand.order("items_count DESC").limit(10)
     @shops = Shop.order("items_count DESC").limit(10)
@@ -13,6 +13,9 @@ class TopsController < ApplicationController
     @checked_items = get_checked_items
     # チェックしたショップ
     @checked_shops = get_checked_shops
+
+    @rankings = get_ranking_items.slice(0, 23)
+
   end
 
   def men

--- a/app/models/checked_item.rb
+++ b/app/models/checked_item.rb
@@ -1,4 +1,4 @@
 class CheckedItem < ApplicationRecord
   belongs_to :user
-  belongs_to :item
+  belongs_to :item, counter_cache: :checked_items_count
 end

--- a/app/models/favorite_item.rb
+++ b/app/models/favorite_item.rb
@@ -1,4 +1,5 @@
 class FavoriteItem < ApplicationRecord
   belongs_to :user
   belongs_to :item_num
+  belongs_to :item, counter_cache: :favorite_items_count
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,10 +8,11 @@ class Item < ApplicationRecord
   has_many :stocks
   has_many :images
   has_many :item_nums
-  # has_many :shoppings, dependent: :destroy
+  has_many :shoppings, dependent: :destroy
   has_many :carts, through: :shoppings
-  # has_many :ordered_items
+  has_many :ordered_items
   # has_many :orders, through: :ordered_items
   has_many :checked_items, dependent: :destroy
+  has_many :favorite_items
   # enum gender: {all: 1, mens: 2, ladies: 3, kids: 4}
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,9 +10,9 @@ class Item < ApplicationRecord
   has_many :item_nums
   has_many :shoppings, dependent: :destroy
   has_many :carts, through: :shoppings
-  has_many :ordered_items
+  has_many :ordered_items, dependent: :destroy
   # has_many :orders, through: :ordered_items
   has_many :checked_items, dependent: :destroy
-  has_many :favorite_items
+  has_many :favorite_items, dependent: :destroy
   # enum gender: {all: 1, mens: 2, ladies: 3, kids: 4}
 end

--- a/app/models/ordered_item.rb
+++ b/app/models/ordered_item.rb
@@ -1,4 +1,4 @@
 class OrderedItem < ApplicationRecord
-  belongs_to :item
+  belongs_to :item, counter_cache: :ordered_items_count
   belongs_to :order
 end

--- a/app/models/shopping.rb
+++ b/app/models/shopping.rb
@@ -1,5 +1,5 @@
 class Shopping < ApplicationRecord
-  belongs_to :item
+  belongs_to :item, counter_cache: :shoppings_count
   belongs_to :cart
   belongs_to :item_num
 end

--- a/app/views/rankings/index.html.haml
+++ b/app/views/rankings/index.html.haml
@@ -2,7 +2,7 @@
   .r.header
     %ul
       %li
-        %a{ :href => 'http://google.co.jp' }ZOZOTOWN
+        = link_to "ZOZOTOWN", root_path
         >
       %li
         人気アイテムランキング
@@ -34,70 +34,12 @@
             すべてのカテゴリー
           %span
             ^
-    .r.ranking-item-content
-      .clearfix
-        .r.ranking-item-large
-          .r.ranking-number
-            1
-          .r.ranking-item-photo
-            %a{ :href => 'http://google.co.jp' }
-              %img{alt: "アイテム写真", height: "372", width: "310", src: "https://c.imgz.jp/481/31242481/31242481_8_D_500.jpg"}
-          .r.ranking-item-set
-            %p
-              ブランド名
-            %p
-              商品名
-            .r.ranking-price
-              ¥2,000
-              %span
-                税込
-        .r.ranking-item-large
-          .r.ranking-number2
-            2
-          .r.ranking-item-photo
-            %a{ :href => 'http://google.co.jp' }
-              %img{alt: "アイテム写真", height: "372", width: "310", src: "https://c.imgz.jp/214/33242214/33242214_385_d_500.jpg"}
-          .r.ranking-item-set
-            %p
-              ブランド名
-            %p
-              商品名
-            .r.ranking-price
-              ¥2,000
-              %span
-                税込
-        .r.ranking-item-large
-          .r.ranking-number3
-            3
-          .r.ranking-item-photo
-            %a{ :href => 'http://google.co.jp' }
-              %img{alt: "アイテム写真", height: "372", width: "310", src: "https://c.imgz.jp/212/33242212/33242212_16_d_500.jpg"}
-          .r.ranking-item-set
-            %p
-              ブランド名
-            %p
-              商品名
-            .r.ranking-price
-              ¥2,000
-              %span
-                税込
-      .r.ranking-sub
-        - 15.times.each do |i|
-          .r.ranking-sub-area
-            .r.ranking-sub-number
-              4
-            .r.ranking-sub-item-photo
-              %a{ :href => 'http://google.co.jp' }
-                %img{alt: "アイテム写真", height: "258", width: "215", src: "https://c.imgz.jp/825/19950825/19950825B_22_D_215.jpg"}
-            .r.ranking-sub-item-set
-              %p
-                ブランド名
-              %p
-                商品名
-              .r.sub-ranking-price
-                ¥2,000
-                %span
-                  税込
-
-
-
+    %ul
+      - @rankings.each_with_index do |ranking, i|
+        - item = ranking[0]
+        - if i < 3
+          %li.item
+            = render partial: 'tops/item', locals: {item: item, image_size: "super-large", rank_num: i + 1, coupon: 0}
+        - else
+          %li.item.sub_ranking
+            = render partial: 'tops/item', locals: {item: item, image_size: "high-large", rank_num: i + 1, coupon: 0}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,9 +15,7 @@ Rails.application.routes.draw do
     get 'orders/select'
     post 'orders/registration'
 
-  get 'rankings/index' => 'rankings#index'
-
-  get 'rankings/index' => 'rankings#index'
+  resources :rankings, only: :index
 
   get "men_top"    => "tops#men"
   get "women_top"  => "tops#women"
@@ -87,4 +85,3 @@ Rails.application.routes.draw do
     end
   end
 end
-

--- a/db/migrate/20181009050138_add_counter_columns.rb
+++ b/db/migrate/20181009050138_add_counter_columns.rb
@@ -1,0 +1,9 @@
+class AddCounterColumns < ActiveRecord::Migration[5.0]
+  def change
+    add_column :items, :favorite_items_count, :integer, default: 0
+    add_column :items, :checked_items_count, :integer, default: 0
+    add_column :items, :shoppings_count, :integer, default: 0
+    add_column :items, :ordered_items_count, :integer, default: 0
+    add_column :favorite_items, :item_id, :integer, foreign_key: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181009033906) do
+ActiveRecord::Schema.define(version: 20181009050138) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",        null: false
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20181009033906) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.integer  "item_num_id", null: false
+    t.integer  "item_id",     null: false
   end
 
   create_table "favorite_shops", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -109,17 +110,21 @@ ActiveRecord::Schema.define(version: 20181009033906) do
   end
 
   create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",                          null: false
-    t.integer  "price",                         null: false
-    t.integer  "gender",                        null: false
-    t.text     "description",     limit: 65535
-    t.integer  "top_category_id",               null: false
-    t.integer  "sub_category_id",               null: false
-    t.integer  "coupon_id",                     null: false
-    t.integer  "brand_id",                      null: false
-    t.integer  "shop_id",                       null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.string   "name",                                           null: false
+    t.integer  "price",                                          null: false
+    t.integer  "gender",                                         null: false
+    t.text     "description",          limit: 65535
+    t.integer  "top_category_id",                                null: false
+    t.integer  "sub_category_id",                                null: false
+    t.integer  "coupon_id",                                      null: false
+    t.integer  "brand_id",                                       null: false
+    t.integer  "shop_id",                                        null: false
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
+    t.integer  "favorite_items_count",               default: 0
+    t.integer  "checked_items_count",                default: 0
+    t.integer  "shoppings_count",                    default: 0
+    t.integer  "ordered_items_count",                default: 0
     t.index ["name"], name: "index_items_on_name", using: :btree
   end
 


### PR DESCRIPTION
# what
ランキング一覧ページ、トップページにランキング一覧表示機能を追加

# why
コンテンツ充実のため

# description
・アイテムのそれぞれにつき、1. アイテム詳細ページの閲覧数、2. お気に入り登録数、3. カートへの登録数、4. 注文数の４つのパラメータのポイントを加算。
各パラメータに重み付けの係数をかけた（係数は差し当たり適当）
・アイテムの登録日から現在日時を算出し、アイテムの登録が早いほどランキングの順位が下がるように設定
・ランキングの順位は１週間単位とした。