### PR TITLE
各ページへのリンクの接続およびログイン前のページに対する処理の追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @cart = current_user.cart
+    if user_signed_in?
+      @cart = current_user.cart
+    end
     @item = Item.find(params[:id])
     @shop = @item.shop
     @images = @item.images
@@ -11,7 +13,9 @@ class ItemsController < ApplicationController
     @color_count = @item.images.group(:color).length - 1 # -1: nilを除外
     @stock_count = @item.stocks.length
 
-    # 「チェックしたアイテム」機能
-    current_user.checked_items.where(item_id: @item.id).first_or_create.update(updated_at: Time.current)
+    if user_signed_in?
+      # 「チェックしたアイテム」機能
+      current_user.checked_items.where(item_id: @item.id).first_or_create.update(updated_at: Time.current)
+    end
   end
 end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -9,10 +9,13 @@ class TopsController < ApplicationController
     @top_categories = TopCategory.all
     @brands = Brand.order("items_count DESC").limit(10)
     @shops = Shop.order("items_count DESC").limit(10)
-    # チェックしたアイテム
-    @checked_items = get_checked_items
-    # チェックしたショップ
-    @checked_shops = get_checked_shops
+
+    if user_signed_in?
+      # チェックしたアイテム
+      @checked_items = get_checked_items
+      # チェックしたショップ
+      @checked_shops = get_checked_shops
+    end
 
     @rankings = get_ranking_items.slice(0, 23)
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -52,7 +52,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # The path used after sign up.
   def after_sign_up_path_for(resource)
-    carts_register_path
+    register_carts_path
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,7 +1,5 @@
 class Cart < ApplicationRecord
   belongs_to :user
-  belongs_to :order
-
   has_many :shoppings
   has_many :items, through: :shoppings
   has_many :item_nums, through: :shoppings

--- a/app/views/carts/index.html.haml
+++ b/app/views/carts/index.html.haml
@@ -71,7 +71,7 @@
                 -# = render partial: 'tops/item', locals: {image_size: "middle", rank_num: 0, coupon: 0, shop_image: false}
     .cart-next
       .form
-        %a{ :href => 'http://google.co.jp' }レジへ進む
+        = link_to "レジへ進む", new_pre_order_path
         .postage
           .postage-text
             %i.fas.fa-exclamation-circle

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -32,7 +32,8 @@
           #top__center__pickup__contents__item
             - @related_items.each_with_index do |item, i|
               - if item.images[0] && i < 8
-                = render partial: 'tops/item',  locals: {item: item, image_size: "middle", rank_num: 0, coupon: 0, shop_image: false}
+                %li.item
+                  = render partial: 'tops/item',  locals: {item: item, image_size: "middle", rank_num: 0, coupon: 0, shop_image: false}
 
     .right-content
       .item-intro
@@ -86,12 +87,13 @@
                     = "#{stock.size} / 在庫なし"
                 %p.size_info
                   = "#{stock.size}サイズ相当"
-              .cart-box.clearfix
-                = link_to carts_create_path(item_id: @item.id, cart_id: @cart.id, item_num_id: @item.item_nums[i].id), method: :post, class: "cart_btn clearfix" do
-                  %i.fas.fa-shopping-cart
-                  %p カートへ入れる
-                .favorite
-                  = render partial: "favorites/favorite_icon", locals: {item: @item, shop: @shop, item_num_id: stock.item_num.id}
+              - if user_signed_in?
+                .cart-box.clearfix
+                  = link_to carts_create_path(item_id: @item.id, cart_id: @cart.id, item_num_id: @item.item_nums[i].id), method: :post, class: "cart_btn clearfix" do
+                    %i.fas.fa-shopping-cart
+                    %p カートへ入れる
+                  .favorite
+                    = render partial: "favorites/favorite_icon", locals: {item: @item, shop: @shop, item_num_id: stock.item_num.id}
       .condition-tab
         .left-tab
           %a{ :href => 'http://google.co.jp' }アイテム説明

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -49,7 +49,7 @@
                     %i.far.fa-heart
                     %span 会員でない方でも「お気に入り」が使えるようになりました。
         %li#header__wrapper__right__contents__cart
-          = link_to "#", class: "h-list-btn", id: "cart-btn" do
+          = link_to carts_index_path, class: "h-list-btn", id: "cart-btn" do
             %i.fas.fa-lg.fa-shopping-cart
             %i.fas.fa-circle
               %i.cart-notify
@@ -60,7 +60,7 @@
                 %i.fas.fa-shopping-cart
                 %span カートに商品が1件あります。
                 .look-cart-btn
-                  = link_to "ショッピングカートを見る", "#"
+                  = link_to "ショッピングカートを見る", carts_index_path
 
         %li#header__wrapper__right__contents__menu
           = link_to "#", class: "h-list-btn", id: "menu-btn" do
@@ -71,10 +71,10 @@
                 %li
                   %h3 探す
                 %li
-                  = link_to "カテゴリー一覧", "#"
+                  = link_to "カテゴリー一覧", top_categories_path
                 %li
-                  = link_to "ブランド一覧", "#"
+                  = link_to "ブランド一覧", brands_path
                 %li
-                  = link_to "ショップ一覧", "#"
+                  = link_to "ショップ一覧", shops_path
                 %li
-                  = link_to "ランキング一覧", "#"
+                  = link_to "ランキング一覧", rankings_path

--- a/app/views/tops/_tops_center.html.haml
+++ b/app/views/tops/_tops_center.html.haml
@@ -36,20 +36,22 @@
   %p.more-list.link-list.zozo-item-link
     = link_to "ランキング一覧", "#"
 //-------- チェックしたアイテム ---------//
-%section#top__center__pickup
-  .section-header
-    %h2 チェックしたアイテム
-  %ul#top__center__pickup__contents.clearfix
-    - @checked_items.each do |item|
-      #top__center__pickup__contents__item
-        %li.item
-          - if item.images[0]
-            = render partial: 'item', locals: {item: item, image_size: "small", rank_num: 0, coupon: 0}
-%section#top__center__shops
-  .section-header
-    %h2 チェックしたショップ
-  %ul#top__center__shops__contents.clearfix
-    - @checked_shops.each do |shop|
-      #top__center__pickup__contents__item
-        - if shop.url
-          = render partial: 'shop_image', locals: {shop: shop}
+- if user_signed_in?
+  %section#top__center__pickup
+    .section-header
+      %h2 チェックしたアイテム
+    %ul#top__center__pickup__contents.clearfix
+      - @checked_items.each do |item|
+        #top__center__pickup__contents__item
+          %li.item
+            - if item.images[0]
+              = render partial: 'item', locals: {item: item, image_size: "small", rank_num: 0, coupon: 0}
+- if user_signed_in?
+  %section#top__center__shops
+    .section-header
+      %h2 チェックしたショップ
+    %ul#top__center__shops__contents.clearfix
+      - @checked_shops.each do |shop|
+        #top__center__pickup__contents__item
+          - if shop.url
+            = render partial: 'shop_image', locals: {shop: shop}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Rails.application.routes.draw do
   get "kid_top"    => "tops#kid"
   get "tests/search" => "tests#search"
 
+  resources :carts, only: [:index, :create, :destroy] do
+    collection do
+      get :register
+    end
+  end
   resources :orders, only: [:index, :create]
   resources :pre_orders, only: [:new, :create]
 


### PR DESCRIPTION
# what
１. 以下、トップページからのリンクを接続した。
・ブランド一覧、ショップ一覧、ランキング一覧、ショッピングカートページ
2. ログアウトした状態でページにアクセスするとエラーとなる不具合を改修
暫定でcurrent_userの参照が必要な記述にはuser_signed_in?の条件式を追加し作業を継続できるようにした
3. cartsコントローラーのルーティングをresource化し整理した。その結果、サインアップ後のカート作成のルーティングの記述を変更した

# why
作業の効率化と不具合改修のため