### PR TITLE
トップページのレイアウト変更

### DIFF
--- a/app/assets/stylesheets/shared/_common.scss
+++ b/app/assets/stylesheets/shared/_common.scss
@@ -63,7 +63,7 @@
 }
 
 .select_lists {
-  margin-top: 25px;
+  margin-top: 20px;
   padding-bottom: 13px;
 }
 

--- a/app/assets/stylesheets/shared/_variables.scss
+++ b/app/assets/stylesheets/shared/_variables.scss
@@ -29,7 +29,7 @@ $top-head-font-color: #2d2d2d;
 $top-list-font-color: #646464;
 //-- layout size ---------//
 $top-left-width: 175px;
-$top-center-width: 540px;
+$top-center-width: 750px;
 $top-right-width: 210px;
 //-- category ------------//
 $top-category-btn-width: 168px;

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -13,7 +13,7 @@ article {
 
         &__list {
           li {
-            margin-top: 10px;
+            margin-top: 5px;
           }
         }
       }
@@ -28,7 +28,6 @@ article {
       }
 
       &__favorite {
-        padding: 22px 0 12px;
 
         &__list {
           border-top: solid 1px $top-category-border-color;
@@ -49,7 +48,6 @@ article {
       }
 
       &__shop {
-        padding: 37px 0 12px;
 
         &__list {
           li {
@@ -63,7 +61,7 @@ article {
 
     &__center {
       width: $top-center-width;
-      margin-left: 15px;
+      margin-left: 25px;
       float: left;
 
       &__zozo {
@@ -87,12 +85,6 @@ article {
       &__shops {
         @include top_set_border;
       }
-    }
-
-    &__right {
-      width: $top-right-width;
-      height: 1000px;
-      float: left;
     }
   }
 }
@@ -207,6 +199,12 @@ article {
 .list-title {
   text-decoration: none;
   color: $top-list-font-color;
+  text-overflow: ellipsis;
+  width: 150px;
+  height: 20px;
+  overflow: hidden;
+  display: inline-block;
+  white-space: nowrap;
 }
 
 .section-header {

--- a/app/controllers/concerns/search.rb
+++ b/app/controllers/concerns/search.rb
@@ -9,7 +9,7 @@ module Search
       elsif url.include?("kids")
         return items.where("(gender = ?) OR (gender = ?)", 3, 4)
       else
-        return @items
+        return items
       end
     end
 

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,12 +1,18 @@
 class TopsController < ApplicationController
   include Checked
   include Ranking
+  include Search
+
   def index
-    @newest_items = Item.order("created_at DESC").includes(:images).limit(9)
-    @coupon_items = Item.order("created_at DESC").includes(:images).limit(9)
-    @top_categories = TopCategory.all
-    @brands = Brand.order("items_count DESC").limit(10)
-    @shops = Shop.order("items_count DESC").limit(10)
+    items = Item.all
+    url = request.path_info
+    @items = search_items_by_gender(url, items)
+
+    @newest_items = @items.order("created_at DESC").includes(:images).limit(9)
+    @coupon_items = @items.order("created_at DESC").includes(:images).limit(9)
+    @top_categories = TopCategory.all.includes(:sub_categories)
+    @brands = Brand.order("items_count DESC").includes(:items).limit(10)
+    @shops = Shop.order("items_count DESC").includes(:items).limit(10)
 
     if user_signed_in?
       # チェックしたアイテム

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -2,22 +2,20 @@ class TopsController < ApplicationController
   include Checked
   include Ranking
   def index
-    @zozo_brand = Brand.find_by(name: "ZOZO")
-    @zozo_items = @zozo_brand.items.limit(3).includes(:images)
-    # @coupon = Coupon.find_by(price: 5000)
-    @coupon_items = Item.order("created_at DESC").limit(7)
+    @newest_items = Item.order("created_at DESC").includes(:images).limit(9)
+    @coupon_items = Item.order("created_at DESC").includes(:images).limit(9)
     @top_categories = TopCategory.all
     @brands = Brand.order("items_count DESC").limit(10)
     @shops = Shop.order("items_count DESC").limit(10)
 
     if user_signed_in?
       # チェックしたアイテム
-      @checked_items = get_checked_items
+      @checked_items = get_checked_items.slice(0, 18)
       # チェックしたショップ
-      @checked_shops = get_checked_shops
+      @checked_shops = get_checked_shops.slice(0, 8)
     end
 
-    @rankings = get_ranking_items.slice(0, 23)
+    @rankings = get_ranking_items.slice(0, 9)
 
   end
 

--- a/app/views/brands/index.html.haml
+++ b/app/views/brands/index.html.haml
@@ -21,7 +21,7 @@
           - brands.each do |brand|
             - if brand.items.length > 0
               %dd
-                = link_to "#" do
+                = link_to brand_path(brand) do
                   %span
                     = brand.name
                 %span

--- a/app/views/shops/index.html.haml
+++ b/app/views/shops/index.html.haml
@@ -21,7 +21,7 @@
           - shops.each do |shop|
             - if shop.items.length > 0
               %dd
-                = link_to "#" do
+                = link_to shop_path(shop) do
                   %span
                     = shop.name
                 %span

--- a/app/views/tops/_tops_center.html.haml
+++ b/app/views/tops/_tops_center.html.haml
@@ -1,10 +1,15 @@
 %section#top__center__zozo
+  .section-header
+    %h2 新着アイテム
   %ul#top__center__zozo__contents.clearfix
-    - @zozo_items.each do |item|
+    - @newest_items.each_with_index do |item, i|
       %li.item
-        = render partial: 'item', locals: {item: item, image_size: "large", rank_num: 0, coupon: 0}
+        - if i < 4
+          = render partial: 'item', locals: {item: item, image_size: "large", rank_num: 0, coupon: 0}
+        - else
+          = render partial: 'item', locals: {item: item, image_size: "middle", rank_num: 0, coupon: 0}
   %p.more-list.link-list
-    = link_to "ZOZOアイテム一覧", "#"
+    = link_to "新着アイテム一覧", "#"
 
 //-------- クーポン対象アイテム ---------//
 %section#top__center__coupon
@@ -13,7 +18,7 @@
   %ul#top__center__coupon__contents.clearfix
     - @coupon_items.each_with_index do |item, i|
       %li.item
-        - if i < 3
+        - if i < 4
           = render partial: 'item', locals: {item: item, image_size: "large", rank_num: 0, coupon: 2000}
         - else
           = render partial: 'item', locals: {item: item, image_size: "middle", rank_num: 0, coupon: 2000}
@@ -29,7 +34,7 @@
       - item = ranking[0]
       #top__center__ranking__contents__item
         %li.item
-          - if i < 3
+          - if i < 4
             = render partial: 'item', locals: {item: item, image_size: "large", rank_num: i+1, coupon: 0}
           - else
             = render partial: 'item', locals: {item: item, image_size: "middle", rank_num: i+1, coupon: 0}

--- a/app/views/tops/_tops_center.html.haml
+++ b/app/views/tops/_tops_center.html.haml
@@ -4,10 +4,11 @@
   %ul#top__center__zozo__contents.clearfix
     - @newest_items.each_with_index do |item, i|
       %li.item
-        - if i < 4
-          = render partial: 'item', locals: {item: item, image_size: "large", rank_num: 0, coupon: 0}
-        - else
-          = render partial: 'item', locals: {item: item, image_size: "middle", rank_num: 0, coupon: 0}
+        - if item.images[0]
+          - if i < 4
+            = render partial: 'item', locals: {item: item, image_size: "large", rank_num: 0, coupon: 0}
+          - else
+            = render partial: 'item', locals: {item: item, image_size: "middle", rank_num: 0, coupon: 0}
   %p.more-list.link-list
     = link_to "新着アイテム一覧", "#"
 
@@ -17,11 +18,12 @@
     %h2 クーポン対象アイテム
   %ul#top__center__coupon__contents.clearfix
     - @coupon_items.each_with_index do |item, i|
-      %li.item
-        - if i < 4
-          = render partial: 'item', locals: {item: item, image_size: "large", rank_num: 0, coupon: 2000}
-        - else
-          = render partial: 'item', locals: {item: item, image_size: "middle", rank_num: 0, coupon: 2000}
+      - if item.images[0]
+        %li.item
+          - if i < 4
+            = render partial: 'item', locals: {item: item, image_size: "large", rank_num: 0, coupon: 2000}
+          - else
+            = render partial: 'item', locals: {item: item, image_size: "middle", rank_num: 0, coupon: 2000}
   %p.more-list.link-list.zozo-item-link
     = link_to "クーポン対象アイテム一覧", "#"
 
@@ -33,11 +35,12 @@
     - @rankings.each_with_index do |ranking, i|
       - item = ranking[0]
       #top__center__ranking__contents__item
-        %li.item
-          - if i < 4
-            = render partial: 'item', locals: {item: item, image_size: "large", rank_num: i+1, coupon: 0}
-          - else
-            = render partial: 'item', locals: {item: item, image_size: "middle", rank_num: i+1, coupon: 0}
+        - if item.images[0]
+          %li.item
+            - if i < 4
+              = render partial: 'item', locals: {item: item, image_size: "large", rank_num: i+1, coupon: 0}
+            - else
+              = render partial: 'item', locals: {item: item, image_size: "middle", rank_num: i+1, coupon: 0}
   %p.more-list.link-list.zozo-item-link
     = link_to "ランキング一覧", "#"
 //-------- チェックしたアイテム ---------//

--- a/app/views/tops/_tops_left.html.haml
+++ b/app/views/tops/_tops_left.html.haml
@@ -18,10 +18,10 @@
   %h2.head-title ブランド
   = render partial: "/tops/left/brand_list", locals: {brands: @brands}
   %p.more-list.link-list
-    = link_to "ブランド一覧", "#"
+    = link_to "ブランド一覧", brands_path
 //--------- ショップリスト--------------
 %section#top__left__shop.clearfix.select_lists
   %h2.head-title ショップ
   = render partial: "/tops/left/shop_list", locals: {shops: @shops}
   %p.more-list.link-list
-    = link_to "ショップ一覧",
+    = link_to "ショップ一覧", shops_path

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -6,5 +6,3 @@
     //-------- センターページ ---------//
     #top__center
       = render "tops_center"
-    //-------- Rightページ ---------//
-    #top__right

--- a/app/views/tops/left/_brand_list.html.haml
+++ b/app/views/tops/left/_brand_list.html.haml
@@ -15,4 +15,4 @@
           .rank-num
             = i+1
       - next_path = request.path_info.sub("tops", "") + "brands/#{brand.id}"
-      = link_to brand.name, next_path, class: "list-title link-list"
+      = link_to brand.name, brand_path(brand), class: "list-title link-list"

--- a/app/views/tops/left/_search_list.html.haml
+++ b/app/views/tops/left/_search_list.html.haml
@@ -1,7 +1,7 @@
 %ul#top__left__search__list
   %li
-    = link_to "ブランドから探す", "#", class: "list-title link-list"
+    = link_to "ブランドから探す", brands_path, class: "list-title link-list"
   %li
-    = link_to "ショップから探す", "#", class: "list-title link-list"
+    = link_to "ショップから探す", shops_path, class: "list-title link-list"
   %li
-    = link_to "ランキングから探す", "#", class: "list-title link-list"
+    = link_to "ランキングから探す", rankings_path, class: "list-title link-list"


### PR DESCRIPTION
# what
・トップページの右側の空白コンテンツを廃止し、アイテムのコンテンツを多く表示するようにした
・トップページのリンクを接続し各ページにアクセスできるようにした。

# why
UI向上