### PR TITLE
アイテム詳細ページの画像スライド機能追加

### DIFF
--- a/app/assets/javascripts/image_slide.js
+++ b/app/assets/javascripts/image_slide.js
@@ -1,10 +1,37 @@
 $(function(){
   $(".sub_image").on("click", function(){
-    image_id = $(this).attr("image-id");
     image_src = $(this).attr("src");
     $(".main-image").empty();
     $(".main-image").append(`<img src=${image_src} class='top_image'>`);
     $(".sub_image").removeClass("selected_image")
     $(this).addClass("selected_image");
+  })
+
+  $(".right-angle").on("click", function(){
+    current_id = Number($(".top_image").attr("id"))
+    length = $(".sub-image-content li").length
+
+    if (current_id < length - 1){
+      next_id = current_id + 1;
+    }else {
+      next_id = 0
+    }
+    next_src = $("#" + String(next_id)).attr("src")
+    $(".main-image").empty();
+    $(".main-image").append(`<img src=${next_src} class='top_image' id='${next_id}'>`);
+  })
+
+  $(".left-angle").on("click", function(){
+    current_id = Number($(".top_image").attr("id"))
+    length = $(".sub-image-content li").length
+
+    if (current_id > 0){
+      next_id = current_id - 1;
+    }else {
+      next_id = length - 1
+    }
+    next_src = $("#" + String(next_id)).attr("src")
+    $(".main-image").empty();
+    $(".main-image").append(`<img src=${next_src} class='top_image' id='${next_id}'>`);
   })
 })

--- a/app/assets/javascripts/image_slide.js
+++ b/app/assets/javascripts/image_slide.js
@@ -9,9 +9,8 @@ $(function(){
 
   $(".right-angle").on("click", function(){
     current_id = Number($(".top_image").attr("id"))
-    length = $(".sub-image-content li").length
 
-    if (current_id < length - 1){
+    if (current_id < $(".sub-image-content li").length - 1){
       next_id = current_id + 1;
     }else {
       next_id = 0
@@ -23,12 +22,11 @@ $(function(){
 
   $(".left-angle").on("click", function(){
     current_id = Number($(".top_image").attr("id"))
-    length = $(".sub-image-content li").length
 
     if (current_id > 0){
       next_id = current_id - 1;
     }else {
-      next_id = length - 1
+      next_id = $(".sub-image-content li").length - 1
     }
     next_src = $("#" + String(next_id)).attr("src")
     $(".main-image").empty();

--- a/app/assets/javascripts/image_slide.js
+++ b/app/assets/javascripts/image_slide.js
@@ -1,0 +1,10 @@
+$(function(){
+  $(".sub_image").on("click", function(){
+    image_id = $(this).attr("image-id");
+    image_src = $(this).attr("src");
+    $(".main-image").empty();
+    $(".main-image").append(`<img src=${image_src} class='top_image'>`);
+    $(".sub_image").removeClass("selected_image")
+    $(this).addClass("selected_image");
+  })
+})

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -53,6 +53,10 @@
             float: left;
           }
         }
+        .fas {
+          color: #808080;
+          cursor: pointer;
+        }
 
         .main-image {
           height: $height-main-content;
@@ -595,9 +599,15 @@
 .top_image {
   width: 500px;
   height: 600px;
+  cursor: pointer;
 }
 
 .sub_image {
   width: 35px;
   height: 42px;
+  cursor: pointer;
+}
+
+.selected_image {
+  border: solid 3px #878787;
 }

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -15,16 +15,16 @@
       .main-image-content
         .left-button
           .button-left
-            <
+            %i.fas.fa-angle-left.fa-2x
         .main-image
           = image_tag @images[0].url, class: "top_image", alt: "商品画像"
         .right-button
           .button-right
-            >
+            %i.fas.fa-angle-right.fa-2x
       .sub-image-content.clearfix
-        - @images.each do |image|
+        - @images.each_with_index do |image, i|
           .sub-image-content-mini
-            = image_tag image.url, class: "sub_image", alt: "商品画像"
+            = image_tag image.url, class: "sub_image", alt: "商品画像", "image-id": i
             %p
               = image.color
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -15,16 +15,16 @@
       .main-image-content
         .left-button
           .button-left
-            %i.fas.fa-angle-left.fa-2x
+            %i.fas.fa-angle-left.fa-2x.left-angle
         .main-image
-          = image_tag @images[0].url, class: "top_image", alt: "商品画像"
+          = image_tag @images[0].url, class: "top_image", alt: "商品画像", id: 0
         .right-button
           .button-right
-            %i.fas.fa-angle-right.fa-2x
-      .sub-image-content.clearfix
+            %i.fas.fa-angle-right.fa-2x.right-angle
+      %ul.sub-image-content.clearfix
         - @images.each_with_index do |image, i|
-          .sub-image-content-mini
-            = image_tag image.url, class: "sub_image", alt: "商品画像", "image-id": i
+          %li.sub-image-content-mini
+            = image_tag image.url, class: "sub_image", alt: "商品画像", id: i
             %p
               = image.color
 


### PR DESCRIPTION
# what
・アイテム詳細ページにおけるアイテム画像横のアングルボタンを押すと画像が切り替わる機能を追加
・サブ画像を選択すると選択した画像がメイン画像として表示される機能を追加
# why
UX向上のため
