### PR TITLE
商品の在庫確認処理を追加

### DIFF
--- a/app/controllers/pre_orders_controller.rb
+++ b/app/controllers/pre_orders_controller.rb
@@ -1,7 +1,8 @@
 class PreOrdersController < ApplicationController
   before_action :authenticate_user!
+  before_action :confirm_user_parameter, only: :new
+  before_action :confirm_item_stock, only: :new
   def new
-    confirm_user_parameter
     @pre_order = PreOrder.new
     @payments = Payment.all
     @deliveries = Delivery.all
@@ -26,6 +27,14 @@ class PreOrdersController < ApplicationController
   def confirm_user_parameter
     if current_user.name.blank? || current_user.phone_num.blank? || current_user.address.blank? || current_user.card_num.blank?
       redirect_to users_path(id: current_user.id, title: "From_order"), alert: "ユーザー情報を入力してください"
+    end
+  end
+
+  def confirm_item_stock
+    current_user.cart.item_nums.each do |item_num|
+      if item_num.stock.stock <= 0
+        redirect_to carts_path, alert: "商品が完売しました"
+      end
     end
   end
 end


### PR DESCRIPTION
# what
注文に進むボタンを押したときに商品の在庫を確認し、在庫が０の場合はカート一覧ページにリダイレクトする処理を追加

# why
在庫が０にも関わらず注文が成立するのを防止するため